### PR TITLE
All interface setlossy set to 0 by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 deployments
+.DS_Store

--- a/guest-apps/vnlsvc/vnlif.c
+++ b/guest-apps/vnlsvc/vnlif.c
@@ -2,6 +2,7 @@
 #include <arpa/inet.h>
 
 bool vnlif_parse(struct vnlif* result, char* input) {
+  memset(result, 0, sizeof(*result));
   char p[160]; char* token;
   strncpy(p, input, 160);
 


### PR DESCRIPTION
The default lossy values of interfaces were not being set to 0. I made a minor modification to set the loss values to 0 at the beginning of run.